### PR TITLE
fix some swiftUI issues

### DIFF
--- a/Sources/WishKit/ViewWrapper/WishListView.swift
+++ b/Sources/WishKit/ViewWrapper/WishListView.swift
@@ -8,14 +8,16 @@
 
 import SwiftUI
 
-struct WishListView: UIViewRepresentable {
-  typealias UIViewType = UIView
-
-  func makeUIView(context: Context) -> UIView {
-    let vc = WishListVC()
-    vc.viewDidLoad()
-    return vc.view
-  }
-
-  func updateUIView(_ uiView: UIView, context: Context) { }
+struct WishListView: UIViewControllerRepresentable {
+    typealias UIViewControllerType = UINavigationController
+    
+    func makeUIViewController(context: Context) -> UIViewControllerType {
+        let vc = WishList.viewController
+        vc.viewDidLoad()
+        // Add nav
+        let nav = UINavigationController(rootViewController: vc)
+        return nav
+    }
+    
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) { }
 }

--- a/Sources/WishKit/WishList.swift
+++ b/Sources/WishKit/WishList.swift
@@ -17,8 +17,9 @@ public struct WishList {
         return WishListVC()
     }
 
-    public static var view: any View {
-        return WishListView()
+    public static var view: some View {
+        WishListView()
+            .ignoresSafeArea(.container)
     }
 
     public static func configure(with apiKey: String) {


### PR DESCRIPTION
Use `some View` instead of `any View` and adding `.ignoresSafeArea(.container)` for avoid white padding on top and bottom View
-> some View is the good way to return a generic SwiftUI View

Remove return -> Not needed for one line code since Swift 5 I gess

Fix wrong representable for SwiftUI
Use `UIViewControllerRepresentable` instead of `UIViewRepresentable` and add the missing `UINavigationController` for bridge with SwifUI


You can test it by adding using this sample code that creates a NavigationLink to display WishLit.view 
In the Preview, 

```
import SwiftUI
import WishKit

struct FeatureRequestView: View {
    var body: some View {
        NavigationView {
            NavigationLink(destination: WishList.view) {
                Text("!Request a new feature")
                    .frame(maxWidth: .infinity, alignment: .leading)
            }
        }
    }
}

struct FeatureRequestView_Previews: PreviewProvider {
    static var previews: some View {
        FeatureRequestView()
    }
}
```

The limiting case is that the NavController is duplicated. Otherwise, it will be necessary to make 

```
struct WishListView: UIViewControllerRepresentable {
    typealias UIViewControllerType = UIViewController
    
    func makeUIViewController(context: Context) -> UIViewControllerType {
        let vc = WishList.viewController
        vc.viewDidLoad()
        return vc
    }
    
    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) { }
}
```

-> But it requires to add the title manually from SwiftUI View. But it can be interesting to locate `Feature request`.

```
struct FeatureRequestView: View {
    var body: some View {
        NavigationView {
            NavigationLink {
                WishList.view
                    .navigationTitle("test")
            } label: {
                Text("!Request a new feature")
                    .frame(maxWidth: .infinity, alignment: .leading)
            }
        }
    }
}
```
