### PR TITLE
Remove UINavigationController from UIViewControllerRepresentable, handle availability of ignoresSafeArea for iOS 13

### DIFF
--- a/Sources/WishKit/ViewWrapper/WishListView.swift
+++ b/Sources/WishKit/ViewWrapper/WishListView.swift
@@ -9,14 +9,12 @@
 import SwiftUI
 
 struct WishListView: UIViewControllerRepresentable {
-    typealias UIViewControllerType = UINavigationController
+    typealias UIViewControllerType = UIViewController
     
     func makeUIViewController(context: Context) -> UIViewControllerType {
         let vc = WishList.viewController
         vc.viewDidLoad()
-        // Add nav
-        let nav = UINavigationController(rootViewController: vc)
-        return nav
+        return vc
     }
     
     func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) { }

--- a/Sources/WishKit/WishList.swift
+++ b/Sources/WishKit/WishList.swift
@@ -18,8 +18,12 @@ public struct WishList {
     }
 
     public static var view: some View {
-        WishListView()
-            .ignoresSafeArea(.container)
+        if #available(iOS 14.0, *) {
+            return WishListView()
+                .ignoresSafeArea(.container)
+        } else {
+            return WishListView()
+        }
     }
 
     public static func configure(with apiKey: String) {


### PR DESCRIPTION
Remove nav from `UIViewControllerRepresentable` otherwise double navigation is presented in case of using NavigationLink / NavigationStack.
Need to setup navigationTitle by yourself when calling it as for all view swift

handle availability of `.ignoresSafeArea(.container)`: not available in iOS 13..