### PR TITLE
Make payment parameter for updateUser method optional

### DIFF
--- a/Sources/WishKit/WishKit.swift
+++ b/Sources/WishKit/WishKit.swift
@@ -148,7 +148,7 @@ extension WishKit {
         sendUserToBackend()
     }
 
-    public static func updateUser(payment: Payment) {
+    public static func updateUser(payment: Payment?) {
         self.user.payment = payment
         sendUserToBackend()
     }


### PR DESCRIPTION
If a user cancels a premium subscription, the payment method for the user should also be updated. Currently, the updateUser() method can only be called with weekly/monthly/yearly payment options. 
This option is now optional to simulate that a user unsubscribed.