### PR TITLE
Call property updates on MainThread after voting

### DIFF
--- a/Sources/WishKit/SwiftUI/WishView.swift
+++ b/Sources/WishKit/SwiftUI/WishView.swift
@@ -156,7 +156,9 @@ struct WishView: View {
             case .success:
                 voteCount += 1
                 hasVoted = true
-                voteActionCompletion()
+                DispatchQueue.main.async {
+                    voteActionCompletion()
+                }
             case .failure(let error):
                 alertModel.alertReason = .voteReturnedError(error.localizedDescription)
                 alertModel.showAlert = true


### PR DESCRIPTION
Hey Martin,

i recognized that Xcode shows a violett warning 

> Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.

on the `approvedWishlist` property in the `WishModel` after upvoting an open wish.
Check the attached screenshots:

<img width="949" alt="Console_Log" src="https://github.com/wishkit/wishkit-ios/assets/12933083/3e7aea7f-19d6-46c8-9d6e-9693d5196ff8">

<img width="1258" alt="Xcode_Warning" src="https://github.com/wishkit/wishkit-ios/assets/12933083/181ca741-6425-446b-84e3-0b48671b581a">



I found out that the `voteActionCompletion()` needs to be put into `DispatchQueue.main.async` as well to avoid this error. 

Feel free to merge my PR or even find a better solution to fix the issue.
Thanks for your awesome repository and keep on the great work.
Looking forward to see you on twitch again.

Best regards,
Sebastian