### PR TITLE
Fix: Resolve Alert Display and View Dismissal Issues in Feature Request Flow

### DIFF
--- a/Sources/WishKit/SwiftUI/CreateWishView.swift
+++ b/Sources/WishKit/SwiftUI/CreateWishView.swift
@@ -60,6 +60,14 @@ struct CreateWishView: View {
                 HStack {
                     Spacer()
                     CloseButton(closeAction: dismissViewAction)
+                        .alert(isPresented: $showConfirmationAlert) {
+                            let button = Alert.Button.default(Text(WishKit.config.localization.ok), action: crossPlatformDismiss)
+                            return Alert(
+                                title: Text(WishKit.config.localization.info),
+                                message: Text(WishKit.config.localization.discardEnteredInformation),
+                                dismissButton: button
+                            )
+                        }
                 }
             }
 
@@ -193,14 +201,6 @@ struct CreateWishView: View {
                         }
 
                     }
-                }
-                .alert(isPresented: $showConfirmationAlert) {
-                    let button = Alert.Button.default(Text(WishKit.config.localization.ok), action: crossPlatformDismiss)
-                    return Alert(
-                        title: Text(WishKit.config.localization.info),
-                        message: Text(WishKit.config.localization.discardEnteredInformation),
-                        dismissButton: button
-                    )
                 }
                 .frame(maxWidth: 700)
                 .padding()


### PR DESCRIPTION
### Fix: Resolve Alert Display and View Dismissal Issues in Feature Request Flow

In SDK version 4.2.0, two regressions were introduced:

1. **Alert Display Issue**: Alerts (both error and success) were not displayed after submitting a feature request. For instance, if an email was required, the alert would not appear. Similarly, upon successful creation of a feature request, no success alert was shown.

2. **View Dismissal Issue**: The view did not dismiss automatically after successfully submitting a new feature request.

**Root Cause**: The issue stemmed from having the `alert(isPresented: $showConfirmationAlert)` modifier attached to the parent `VStack` on line 197, while also using `.alert(isPresented: $alertModel.showAlert)` on a `WKButton` child view. In the previous API (before iOS 15), if a parent view had an `.alert()` modifier, it would override any alerts defined in child views further down the hierarchy, preventing the child's alert from being displayed, even though the code was executed.

**Fix**: The `.alert` modifier on the parent `VStack` has been moved to the child view it is associated with. This adjustment ensures that alerts are displayed as expected in all cases and that the view dismisses correctly after a successful submission.