### PR TITLE
Fix #82 : Submission form remains open after successful feature submission

### DIFF
--- a/Sources/WishKit/macOS/CreateWish/View/CreateWishView+macOS.swift
+++ b/Sources/WishKit/macOS/CreateWish/View/CreateWishView+macOS.swift
@@ -10,22 +10,34 @@
 import SwiftUI
 import WishKitShared
 
-struct CreateWishView: View {
+enum ActiveAlert: Identifiable {
+    case success
+    case confirmDiscard
+    case emailRequired
+    case emailFormatWrong
+    case createError(String)
 
-    @Environment(\.presentationMode)
-    var presentationMode
+    var id: String {
+        switch self {
+        case .success: return "success"
+        case .confirmDiscard: return "confirmDiscard"
+        case .emailRequired: return "emailRequired"
+        case .emailFormatWrong: return "emailFormatWrong"
+        case .createError(let text): return "createError-\(text)"
+        }
+    }
+}
+
+struct CreateWishView: View {
 
     @Environment(\.colorScheme)
     private var colorScheme
-
-    @ObservedObject
-    private var alertModel = AlertModel()
 
     @StateObject
     private var viewModel = CreateWishViewModel()
 
     @State
-    private var showConfirmationAlert = false
+    private var activeAlert: ActiveAlert? = nil
 
     @FocusState
     private var titleFieldFocused: Bool
@@ -142,16 +154,37 @@ struct CreateWishView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backgroundColor)
-        .alert(isPresented: $alertModel.showAlert, content: makeAlert)
-        .alert(isPresented: $showConfirmationAlert) {
-            let button = Alert.Button.default(Text(WishKit.config.localization.ok), action: { closeAction?() })
-
-            return Alert(
-                title: Text(WishKit.config.localization.info),
-                message: Text(WishKit.config.localization.discardEnteredInformation),
-                primaryButton: button,
-                secondaryButton: .cancel()
-            )
+        .alert(item: $activeAlert) { alert in
+            switch alert {
+            case .success:
+                return Alert(
+                    title: Text(WishKit.config.localization.info),
+                    message: Text(WishKit.config.localization.successfullyCreated),
+                    dismissButton: .default(Text(WishKit.config.localization.ok)) {
+                        createActionCompletion()
+                        closeAction?()
+                    }
+                )
+            case .confirmDiscard:
+                return Alert(
+                    title: Text(WishKit.config.localization.info),
+                    message: Text(WishKit.config.localization.discardEnteredInformation),
+                    primaryButton: .default(Text(WishKit.config.localization.ok)) { closeAction?() },
+                    secondaryButton: .cancel()
+                )
+            case .emailRequired:
+                return Alert(title: Text(WishKit.config.localization.info),
+                             message: Text(WishKit.config.localization.emailRequiredText),
+                             dismissButton: .default(Text(WishKit.config.localization.ok)))
+            case .emailFormatWrong:
+                return Alert(title: Text(WishKit.config.localization.info),
+                             message: Text(WishKit.config.localization.emailFormatWrongText),
+                             dismissButton: .default(Text(WishKit.config.localization.ok)))
+            case .createError(let errorText):
+                return Alert(title: Text(WishKit.config.localization.info),
+                             message: Text(errorText),
+                             dismissButton: .default(Text(WishKit.config.localization.ok)))
+            }
         }
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
@@ -167,78 +200,27 @@ struct CreateWishView: View {
     }
 
     private func submitAction() {
+        guard !viewModel.isButtonLoading else { return }
         Task { @MainActor in
             let result = await viewModel.submit()
             switch result {
             case .success:
-                alertModel.alertReason = .successfullyCreated
+                activeAlert = .success
             case .emailRequired:
-                alertModel.alertReason = .emailRequired
+                activeAlert = .emailRequired
             case .emailFormatWrong:
-                alertModel.alertReason = .emailFormatWrong
+                activeAlert = .emailFormatWrong
             case .createReturnedError(let errorText):
-                alertModel.alertReason = .createReturnedError(errorText)
+                activeAlert = .createError(errorText)
             }
-            alertModel.showAlert = true
         }
     }
 
     private func dismissViewAction() {
         if !viewModel.titleText.isEmpty || !viewModel.descriptionText.isEmpty || !viewModel.emailText.isEmpty {
-            showConfirmationAlert = true
+            activeAlert = .confirmDiscard
         } else {
             closeAction?()
-        }
-    }
-
-    private func dismissAction() {
-        presentationMode.wrappedValue.dismiss()
-    }
-
-    private func makeAlert() -> Alert {
-        switch alertModel.alertReason {
-        case .successfullyCreated:
-            let button = Alert.Button.default(
-                Text(WishKit.config.localization.ok),
-                action: {
-                    createActionCompletion()
-                    closeAction?()
-                    dismissAction()
-                }
-            )
-            return Alert(
-                title: Text(WishKit.config.localization.info),
-                message: Text(WishKit.config.localization.successfullyCreated),
-                dismissButton: button
-            )
-        case .createReturnedError(let errorText):
-            return Alert(
-                title: Text(WishKit.config.localization.info),
-                message: Text(errorText),
-                dismissButton: .default(Text(WishKit.config.localization.ok))
-            )
-        case .emailRequired:
-            return Alert(
-                title: Text(WishKit.config.localization.info),
-                message: Text(WishKit.config.localization.emailRequiredText),
-                dismissButton: .default(Text(WishKit.config.localization.ok))
-            )
-        case .emailFormatWrong:
-            return Alert(
-                title: Text(WishKit.config.localization.info),
-                message: Text(WishKit.config.localization.emailFormatWrongText),
-                dismissButton: .default(Text(WishKit.config.localization.ok))
-            )
-        case .none:
-            return Alert(
-                title: Text(""),
-                dismissButton: .default(Text(WishKit.config.localization.ok))
-            )
-        default:
-            return Alert(
-                title: Text(""),
-                dismissButton: .default(Text(WishKit.config.localization.ok))
-            )
         }
     }
 }


### PR DESCRIPTION
## Problem
On macOS, after successfully submitting a new wish via `CreateWishView`, the success alert was never appearing. Users would tap Save and nothing visible would happen no confirmation, no window close even though the wish was successfully created on the backend.

## Root cause
`CreateWishView` had **two separate `.alert(isPresented:)` modifiers** attached to the same view one driven by `alertModel.showAlert` and another by `showConfirmationAlert`. On macOS, two separate `.alert(isPresented:)` modifiers on the same view appear to conflict the success alert's content was built but never actually presented on screen. 

## Fix
- Replaced both `.alert(isPresented:)` modifiers with a single `.alert(item:)` driven by one `ActiveAlert` enum, so there's exactly one alert presentation attached to the view at any time.
- Moved `createActionCompletion()` / `closeAction()` directly into the alert's own `dismissButton` action, so they only fire once SwiftUI has taken ownership of dismissing that alert — removing the need for the `DispatchQueue.main.async` workaround.
- Added a synchronous guard (`guard !viewModel.isButtonLoading`) at the top of `submitAction()` to prevent double-submission from rapid double clicks.
- Removed the now-unused `AlertModel` and `presentationMode` dependency.

## Testing
- Verified single Save tap → success alert appears → tapping OK closes the sheet and refreshes the list.
- Verified Cancel with unsaved text still shows the discard confirmation alert and behaves correctly.